### PR TITLE
Include config in test setup

### DIFF
--- a/scripts/browserstack-local.js
+++ b/scripts/browserstack-local.js
@@ -6,12 +6,13 @@ if(process.argv[2]){
 }
 
 var browserstack = require('browserstack-local');
+var config = require('../testem.json');
 var fs = require('fs');
 
 var pidFile = 'browserstack-local.pid';
 var bs_local = new browserstack.Local();
 var bs_local_args = {
-  'key': process.env.BROWSERSTACK_ACCESS_KEY,
+  'key': process.env.BROWSERSTACK_ACCESS_KEY || config.bs_key,
   'forcelocal': true,
   'v': true
 };


### PR DESCRIPTION
I was try to setup `testem` with this sample project, but the method describe in the `README` is not correct where the `scripts/browserstack-local.js` would not pull in values from `testem.json`.

This PR include the config so that when you set the value at the `testem.json` the test will run without issue.