### PR TITLE
Support for "localIdentifier" setting/capability & Avoiding testem default browser start timeout

### DIFF
--- a/scripts/browserstack.js
+++ b/scripts/browserstack.js
@@ -37,6 +37,10 @@ var settings = {
   build: 'testem-browserstack'
 };
 
+if (process.env.BROWSERSTACK_LOCAL_IDENTIFIER) {
+  settings['browserstack.localIdentifier'] = process.env.BROWSERSTACK_LOCAL_IDENTIFIER
+}
+
 for (var i in settings) {
   if (settings[i] === null || settings[i] === '' || settings[i] === 'nil') {
     delete settings[i];

--- a/testem.json
+++ b/testem.json
@@ -4,6 +4,7 @@
 
   "framework": "jasmine",
   "parallel": 4,
+  "browser_start_timeout" : 600,
   
   "on_start": {
     "command": "kill -9 $(ps -A | grep BrowserStackLocal | grep -v grep | cut -d ' ' -f2); ./scripts/browserstack-local.js &",


### PR DESCRIPTION
## Travis integration - localIdentifier

As described in https://docs.travis-ci.com/user/browserstack/ and https://www.browserstack.com/automate/travisci, when using Selenium, there is a identifier associated with each local connection created, and it is provided in the environment variable BROWSERSTACK_LOCAL_IDENTIFIER and must be included in the settings, in case multiple local connections are used.

The change in this commit takes the ruby selenium webdriver example described in above links, and provides the same steps for this testem browserstack integration. This change has been verified with a Travis build running testem ci for the repository https://github.com/reeteshranjan/browse.js.

## Testem browser start timeout

Testem has a default browser start timeout of 30 seconds, which hits few times while trying to run BrowserStack tests using testem. The default setting is being overridden with a timeout of 600 (10 minutes) which should avoid this in most cases.

The error message that pops up when this timeout occurs is the following:

"Browser failed to connect within 30s. testem.js not loaded?"